### PR TITLE
Rename acpi_handle_t → acpi_nsnode_t to better reflect its purpose

### DIFF
--- a/kernel/src/acpi/lai/src/eval.c
+++ b/kernel/src/acpi/lai/src/eval.c
@@ -120,7 +120,7 @@ size_t acpi_eval_object(acpi_object_t *destination, acpi_state_t *state, void *d
     size_t integer_size;
     uint64_t integer;
     size_t name_size;
-    acpi_handle_t *handle;
+    acpi_nsnode_t *handle;
     char name[ACPI_MAX_NAME];
     acpi_object_t *destination_reg;
     acpi_object_t *sizeof_object;
@@ -585,7 +585,7 @@ size_t acpi_eval_object(acpi_object_t *destination, acpi_state_t *state, void *d
         name_size = acpins_resolve_path(name, &object[0]);
         return_size += name_size;
 
-        acpi_handle_t *handle = acpi_exec_resolve(name);
+        acpi_nsnode_t *handle = acpi_exec_resolve(name);
         destination->type = ACPI_INTEGER;
 
         if(!handle)
@@ -650,7 +650,7 @@ size_t acpi_eval_object(acpi_object_t *destination, acpi_state_t *state, void *d
 
 int acpi_eval(acpi_object_t *destination, char *path)
 {
-    acpi_handle_t *handle;
+    acpi_nsnode_t *handle;
     handle = acpi_exec_resolve(path);
     if(!handle)
         return 1;

--- a/kernel/src/acpi/lai/src/exec.c
+++ b/kernel/src/acpi/lai/src/exec.c
@@ -39,7 +39,7 @@ const char *supported_osi_strings[] =
 
 int acpi_exec_method(acpi_state_t *state, acpi_object_t *method_return)
 {
-    acpi_handle_t *method;
+    acpi_nsnode_t *method;
 
     uint32_t osi_return = 0;
 
@@ -347,7 +347,7 @@ size_t acpi_methodinvoke(void *data, acpi_state_t *old_state, acpi_object_t *met
     return_size += name_size;
     methodinvokation += name_size;
 
-    acpi_handle_t *method;
+    acpi_nsnode_t *method;
     method = acpi_exec_resolve(state->name);
     if(!method)
     {

--- a/kernel/src/acpi/lai/src/exec2.c
+++ b/kernel/src/acpi/lai/src/exec2.c
@@ -21,11 +21,11 @@
 
 // acpi_exec_resolve(): Resolves a name during control method execution
 // Param:    char *path - 4-char object name or full path
-// Return:    acpi_handle_t * - pointer to namespace object, NULL on error
+// Return:    acpi_nsnode_t * - pointer to namespace object, NULL on error
 
-acpi_handle_t *acpi_exec_resolve(char *path)
+acpi_nsnode_t *acpi_exec_resolve(char *path)
 {
-    acpi_handle_t *object;
+    acpi_nsnode_t *object;
     object = acpins_resolve(path);
 
     if(acpi_strlen(path) == 4)
@@ -164,7 +164,7 @@ size_t acpi_write_object(void *data, acpi_object_t *source, acpi_state_t *state)
         char name[ACPI_MAX_NAME];
         size_t name_size;
         name_size = acpins_resolve_path(name, dest);
-        acpi_handle_t *handle = acpi_exec_resolve(name);
+        acpi_nsnode_t *handle = acpi_exec_resolve(name);
         if(!handle)
         {
             acpi_panic("acpi: undefined reference %s\n", name);
@@ -212,13 +212,13 @@ size_t acpi_write_object(void *data, acpi_object_t *source, acpi_state_t *state)
 }
 
 // acpi_write_buffer(): Writes to a Buffer Field
-// Param:    acpi_handle_t *handle - handle of buffer field
+// Param:    acpi_nsnode_t *handle - handle of buffer field
 // Param:    acpi_object_t *source - object to write
 // Return:    Nothing
 
-void acpi_write_buffer(acpi_handle_t *handle, acpi_object_t *source)
+void acpi_write_buffer(acpi_nsnode_t *handle, acpi_object_t *source)
 {
-    acpi_handle_t *buffer_handle;
+    acpi_nsnode_t *buffer_handle;
     buffer_handle = acpins_resolve(handle->buffer);
 
     if(!buffer_handle)

--- a/kernel/src/acpi/lai/src/execns.c
+++ b/kernel/src/acpi/lai/src/execns.c
@@ -22,7 +22,7 @@ size_t acpi_exec_name(void *data, acpi_state_t *state)
     char path[ACPI_MAX_NAME];
     size_t size = acpins_resolve_path(path, name);
 
-    acpi_handle_t *handle;
+    acpi_nsnode_t *handle;
     handle = acpins_resolve(path);
     if(!handle)
     {

--- a/kernel/src/acpi/lai/src/lai.h
+++ b/kernel/src/acpi/lai/src/lai.h
@@ -203,7 +203,7 @@ typedef struct acpi_object_t
     char name[ACPI_MAX_NAME];    // for Name References
 } acpi_object_t;
 
-typedef struct acpi_handle_t
+typedef struct acpi_nsnode_t
 {
     char path[ACPI_MAX_NAME];    // full path of object
     int type;
@@ -237,7 +237,7 @@ typedef struct acpi_handle_t
     char buffer[ACPI_MAX_NAME];        // for Buffer field
     uint64_t buffer_offset;        // for Buffer field, in bits
     uint64_t buffer_size;        // for Buffer field, in bits
-} acpi_handle_t;
+} acpi_nsnode_t;
 
 typedef struct acpi_condition_t
 {
@@ -299,7 +299,7 @@ typedef struct acpi_large_irq_t
 
 acpi_fadt_t *acpi_fadt;
 acpi_aml_t *acpi_dsdt;
-acpi_handle_t *acpi_namespace;
+acpi_nsnode_t *acpi_namespace;
 extern char acpins_path[];
 size_t acpi_namespace_entries;
 
@@ -353,22 +353,22 @@ size_t acpins_create_bytefield(void *);
 size_t acpins_create_wordfield(void *);
 size_t acpins_create_dwordfield(void *);
 size_t acpins_create_qwordfield(void *);
-acpi_handle_t *acpins_resolve(char *);
-acpi_handle_t *acpins_get_device(size_t);
-acpi_handle_t *acpins_get_deviceid(size_t, acpi_object_t *);
+acpi_nsnode_t *acpins_resolve(char *);
+acpi_nsnode_t *acpins_get_device(size_t);
+acpi_nsnode_t *acpins_get_deviceid(size_t, acpi_object_t *);
 void acpi_eisaid(acpi_object_t *, char *);
-size_t acpi_read_resource(acpi_handle_t *, acpi_resource_t *);
+size_t acpi_read_resource(acpi_nsnode_t *, acpi_resource_t *);
 
 // ACPI Control Methods
 size_t acpi_eval_object(acpi_object_t *, acpi_state_t *, void *);
 int acpi_eval(acpi_object_t *, char *);
 void acpi_copy_object(acpi_object_t *, acpi_object_t *);
 size_t acpi_write_object(void *, acpi_object_t *, acpi_state_t *);
-acpi_handle_t *acpi_exec_resolve(char *);
+acpi_nsnode_t *acpi_exec_resolve(char *);
 int acpi_exec_method(acpi_state_t *, acpi_object_t *);
 size_t acpi_methodinvoke(void *, acpi_state_t *, acpi_object_t *);
-void acpi_read_opregion(acpi_object_t *, acpi_handle_t *);
-void acpi_write_opregion(acpi_handle_t *, acpi_object_t *);
+void acpi_read_opregion(acpi_object_t *, acpi_nsnode_t *);
+void acpi_write_opregion(acpi_nsnode_t *, acpi_object_t *);
 size_t acpi_exec_store(void *, acpi_state_t *);
 size_t acpi_exec_add(void *, acpi_state_t *);
 size_t acpi_exec_name(void *, acpi_state_t *);
@@ -388,7 +388,7 @@ uint32_t acpi_bswap32(uint32_t);
 uint8_t acpi_char_to_hex(char);
 size_t acpi_exec_multiply(void *, acpi_state_t *);
 size_t acpi_exec_divide(void *, acpi_state_t *);
-void acpi_write_buffer(acpi_handle_t *, acpi_object_t *);
+void acpi_write_buffer(acpi_nsnode_t *, acpi_object_t *);
 size_t acpi_exec_bytefield(void *, acpi_state_t *);
 size_t acpi_exec_wordfield(void *, acpi_state_t *);
 size_t acpi_exec_dwordfield(void *, acpi_state_t *);

--- a/kernel/src/acpi/lai/src/ns.c
+++ b/kernel/src/acpi/lai/src/ns.c
@@ -17,7 +17,7 @@ size_t acpi_acpins_count = 0;
 extern char aml_test[];
 char acpins_path[ACPI_MAX_NAME];
 
-acpi_handle_t *acpi_namespace;
+acpi_nsnode_t *acpi_namespace;
 size_t acpi_namespace_entries = 0;
 
 acpi_state_t acpins_state;    // not really used
@@ -113,7 +113,7 @@ void acpins_increment_namespace()
 {
     acpi_namespace_entries++;
     if((acpi_namespace_entries % ACPI_MAX_NAMESPACE_ENTRIES) == 0)
-        acpi_namespace = acpi_realloc(acpi_namespace, (acpi_namespace_entries + ACPI_MAX_NAMESPACE_ENTRIES + 1) * sizeof(acpi_handle_t));
+        acpi_namespace = acpi_realloc(acpi_namespace, (acpi_namespace_entries + ACPI_MAX_NAMESPACE_ENTRIES + 1) * sizeof(acpi_nsnode_t));
 }
 
 // acpi_create_namespace(): Initializes the AML interpreter and creates the ACPI namespace
@@ -127,7 +127,7 @@ void acpi_create_namespace(void *dsdt)
 
     acpi_acpins_code = acpi_malloc(CODE_WINDOW);
     acpi_acpins_allocation = CODE_WINDOW;
-    acpi_namespace = acpi_calloc(sizeof(acpi_handle_t), ACPI_MAX_NAMESPACE_ENTRIES);
+    acpi_namespace = acpi_calloc(sizeof(acpi_nsnode_t), ACPI_MAX_NAMESPACE_ENTRIES);
 
     //acpins_load_table(aml_test);    // custom AML table just for testing
 
@@ -452,7 +452,7 @@ size_t acpins_create_field(void *data)
     field += pkgsize;
 
     // determine name of opregion
-    acpi_handle_t *opregion;
+    acpi_nsnode_t *opregion;
     char opregion_name[ACPI_MAX_NAME];
     size_t name_size = 0;
 
@@ -1189,9 +1189,9 @@ size_t acpins_create_qwordfield(void *data)
 
 // acpins_resolve(): Returns a namespace object from its path
 // Param:    char *path - 4-char object name or full path
-// Return:    acpi_handle_t * - pointer to namespace object, NULL on error
+// Return:    acpi_nsnode_t * - pointer to namespace object, NULL on error
 
-acpi_handle_t *acpins_resolve(char *path)
+acpi_nsnode_t *acpins_resolve(char *path)
 {
     size_t i = 0;
 
@@ -1225,9 +1225,9 @@ acpi_handle_t *acpins_resolve(char *path)
 
 // acpins_get_device(): Returns a device by its index
 // Param:    size_t index - index
-// Return:    acpi_handle_t * - device handle, NULL on error
+// Return:    acpi_nsnode_t * - device handle, NULL on error
 
-acpi_handle_t *acpins_get_device(size_t index)
+acpi_nsnode_t *acpins_get_device(size_t index)
 {
     size_t i = 0, j = 0;
     while(j < acpi_namespace_entries)
@@ -1247,13 +1247,13 @@ acpi_handle_t *acpins_get_device(size_t index)
 // acpins_get_deviceid(): Returns a device by its index and its ID
 // Param:    size_t index - index
 // Param:    acpi_object_t *id - device ID
-// Return:    acpi_handle_t * - device handle, NULL on error
+// Return:    acpi_nsnode_t * - device handle, NULL on error
 
-acpi_handle_t *acpins_get_deviceid(size_t index, acpi_object_t *id)
+acpi_nsnode_t *acpins_get_deviceid(size_t index, acpi_object_t *id)
 {
     size_t i = 0, j = 0;
 
-    acpi_handle_t *handle;
+    acpi_nsnode_t *handle;
     char path[ACPI_MAX_NAME];
     acpi_object_t device_id;
 

--- a/kernel/src/acpi/lai/src/opregion.c
+++ b/kernel/src/acpi/lai/src/opregion.c
@@ -12,17 +12,17 @@
 
 #include "lai.h"
 
-void acpi_read_field(acpi_object_t *, acpi_handle_t *);
-void acpi_write_field(acpi_handle_t *, acpi_object_t *);
-void acpi_read_indexfield(acpi_object_t *, acpi_handle_t *);
-void acpi_write_indexfield(acpi_handle_t *, acpi_object_t *);
+void acpi_read_field(acpi_object_t *, acpi_nsnode_t *);
+void acpi_write_field(acpi_nsnode_t *, acpi_object_t *);
+void acpi_read_indexfield(acpi_object_t *, acpi_nsnode_t *);
+void acpi_write_indexfield(acpi_nsnode_t *, acpi_object_t *);
 
 // acpi_read_opregion(): Reads from an OpRegion Field or IndexField
 // Param:    acpi_object_t *destination - where to read data
-// Param:    acpi_handle_t *field - field or index field
+// Param:    acpi_nsnode_t *field - field or index field
 // Return:    Nothing
 
-void acpi_read_opregion(acpi_object_t *destination, acpi_handle_t *field)
+void acpi_read_opregion(acpi_object_t *destination, acpi_nsnode_t *field)
 {
     if(field->type == ACPI_NAMESPACE_FIELD)
         return acpi_read_field(destination, field);
@@ -34,11 +34,11 @@ void acpi_read_opregion(acpi_object_t *destination, acpi_handle_t *field)
 }
 
 // acpi_write_opregion(): Writes to a OpRegion Field or IndexField
-// Param:    acpi_handle_t *field - field or index field
+// Param:    acpi_nsnode_t *field - field or index field
 // Param:    acpi_object_t *source - data to write
 // Return:    Nothing
 
-void acpi_write_opregion(acpi_handle_t *field, acpi_object_t *source)
+void acpi_write_opregion(acpi_nsnode_t *field, acpi_object_t *source)
 {
     if(field->type == ACPI_NAMESPACE_FIELD)
         return acpi_write_field(field, source);
@@ -51,12 +51,12 @@ void acpi_write_opregion(acpi_handle_t *field, acpi_object_t *source)
 
 // acpi_read_field(): Reads from a normal field
 // Param:    acpi_object_t *destination - where to read data
-// Param:    acpi_handle_t *field - field
+// Param:    acpi_nsnode_t *field - field
 // Return:    Nothing
 
-void acpi_read_field(acpi_object_t *destination, acpi_handle_t *field)
+void acpi_read_field(acpi_object_t *destination, acpi_nsnode_t *field)
 {
-    acpi_handle_t *opregion;
+    acpi_nsnode_t *opregion;
     opregion = acpins_resolve(field->field_opregion);
     if(!opregion)
     {
@@ -207,14 +207,14 @@ void acpi_read_field(acpi_object_t *destination, acpi_handle_t *field)
 }
 
 // acpi_write_field(): Writes to a normal field
-// Param:    acpi_handle_t *field - field
+// Param:    acpi_nsnode_t *field - field
 // Param:    acpi_object_t *source - data to write
 // Return:    Nothing
 
-void acpi_write_field(acpi_handle_t *field, acpi_object_t *source)
+void acpi_write_field(acpi_nsnode_t *field, acpi_object_t *source)
 {
     // determine the flags we need in order to write
-    acpi_handle_t *opregion;
+    acpi_nsnode_t *opregion;
     opregion = acpins_resolve(field->field_opregion);
     if(!opregion)
     {
@@ -438,12 +438,12 @@ void acpi_write_field(acpi_handle_t *field, acpi_object_t *source)
 
 // acpi_read_indexfield(): Reads from an IndexField
 // Param:    acpi_object_t *destination - destination to read into
-// Param:    acpi_handle_t *indexfield - index field
+// Param:    acpi_nsnode_t *indexfield - index field
 // Return:    Nothing
 
-void acpi_read_indexfield(acpi_object_t *destination, acpi_handle_t *indexfield)
+void acpi_read_indexfield(acpi_object_t *destination, acpi_nsnode_t *indexfield)
 {
-    acpi_handle_t *field;
+    acpi_nsnode_t *field;
     field = acpins_resolve(indexfield->indexfield_index);
     if(!field)
     {
@@ -466,13 +466,13 @@ void acpi_read_indexfield(acpi_object_t *destination, acpi_handle_t *indexfield)
 }
 
 // acpi_write_indexfield(): Writes to an IndexField
-// Param:    acpi_handle_t *indexfield - index field
+// Param:    acpi_nsnode_t *indexfield - index field
 // Param:    acpi_object_t *source - data to write
 // Return:    Nothing
 
-void acpi_write_indexfield(acpi_handle_t *indexfield, acpi_object_t *source)
+void acpi_write_indexfield(acpi_nsnode_t *indexfield, acpi_object_t *source)
 {
-    acpi_handle_t *field;
+    acpi_nsnode_t *field;
     field = acpins_resolve(indexfield->indexfield_index);
     if(!field)
     {

--- a/kernel/src/acpi/lai/src/pciroute.c
+++ b/kernel/src/acpi/lai/src/pciroute.c
@@ -41,7 +41,7 @@ int acpi_pci_route(acpi_resource_t *dest, uint8_t bus, uint8_t slot, uint8_t fun
     acpi_eisaid(&pnp_id, PCI_PNP_ID);
 
     size_t index = 0;
-    acpi_handle_t *handle = acpins_get_deviceid(index, &pnp_id);
+    acpi_nsnode_t *handle = acpins_get_deviceid(index, &pnp_id);
     char path[ACPI_MAX_NAME];
     int status;
 
@@ -137,7 +137,7 @@ resolve_pin:
     if(status != 0)
         return 1;
 
-    acpi_handle_t *link;        // PCI link device
+    acpi_nsnode_t *link;        // PCI link device
     acpi_resource_t *res;
     size_t res_count;
 

--- a/kernel/src/acpi/lai/src/resource.c
+++ b/kernel/src/acpi/lai/src/resource.c
@@ -25,11 +25,11 @@
 #define ACPI_LARGE_IRQ            0x89
 
 // acpi_read_resource(): Reads a device's resource settings
-// Param:    acpi_handle_t *device - device handle
+// Param:    acpi_nsnode_t *device - device handle
 // Param:    acpi_resource_t *dest - destination array
 // Return:    size_t - count of entries successfully read
 
-size_t acpi_read_resource(acpi_handle_t *device, acpi_resource_t *dest)
+size_t acpi_read_resource(acpi_nsnode_t *device, acpi_resource_t *dest)
 {
     char crs[ACPI_MAX_NAME];
     acpi_strcpy(crs, device->path);

--- a/kernel/src/acpi/lai/src/sleep.c
+++ b/kernel/src/acpi/lai/src/sleep.c
@@ -26,7 +26,7 @@ int acpi_enter_sleep(uint8_t state)
     sleep_object[2] = state + '0';
 
     // get sleeping package
-    acpi_handle_t *handle = acpins_resolve((char*)sleep_object);
+    acpi_nsnode_t *handle = acpins_resolve((char*)sleep_object);
     if(!handle)
     {
         acpi_debug("acpi: sleep state %d is not supported.\n", state);


### PR DESCRIPTION
struct acpi_handle_t is not really a handle but the namespace node that is being handled. Change the name to reflect this.