### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Generic object files and binaries.
+*.o
+*.bin
+*.hdd
+
+# Specific files.
+echfs-utils/echfs-utils
+kernel/winkern


### PR DESCRIPTION
Having all `.o` files appear in `git status` is annoying. Let's fix that.