### PR TITLE
Allocate individual NS nodes

### DIFF
--- a/kernel/src/acpi/lai/src/execns.c
+++ b/kernel/src/acpi/lai/src/execns.c
@@ -7,6 +7,7 @@
 /* ACPI Namespace Management During Control Method Execution */
 
 #include "lai.h"
+#include "ns_impl.h"
 
 // acpi_exec_name(): Creates a Name() object in a Method's private namespace
 // Param:    void *data - data
@@ -27,11 +28,10 @@ size_t acpi_exec_name(void *data, acpi_state_t *state)
     if(!handle)
     {
         // create it if it doesn't already exist
-        acpi_namespace[acpi_namespace_entries].type = ACPI_NAMESPACE_NAME;
-        acpi_strcpy(acpi_namespace[acpi_namespace_entries].path, path);
-        handle = &acpi_namespace[acpi_namespace_entries];
-
-        acpins_increment_namespace();
+        handle = acpins_create_nsnode_or_die();
+        handle->type = ACPI_NAMESPACE_NAME;
+        acpi_strcpy(handle->path, path);
+        acpins_install_nsnode(handle);
     }
 
     return_size += size;

--- a/kernel/src/acpi/lai/src/lai.h
+++ b/kernel/src/acpi/lai/src/lai.h
@@ -299,9 +299,7 @@ typedef struct acpi_large_irq_t
 
 acpi_fadt_t *acpi_fadt;
 acpi_aml_t *acpi_dsdt;
-acpi_nsnode_t *acpi_namespace;
 extern char acpins_path[];
-size_t acpi_namespace_entries;
 
 // OS-specific functions
 void *acpi_scan(char *, size_t);
@@ -329,7 +327,6 @@ void acpi_sleep(uint64_t);
 
 // The remaining of these functions are OS independent!
 // ACPI namespace functions
-void acpins_increment_namespace();
 size_t acpins_resolve_path(char *, uint8_t *);
 void acpi_create_namespace(void *);
 int acpi_is_name(char);

--- a/kernel/src/acpi/lai/src/lai.h
+++ b/kernel/src/acpi/lai/src/lai.h
@@ -16,7 +16,6 @@
 #define ACPI_GAS_IO            1
 #define ACPI_GAS_PCI            2
 
-#define ACPI_MAX_NAMESPACE_ENTRIES    128    // realloc()'d, to save memory
 #define ACPI_MAX_PACKAGE_ENTRIES    256    // for Package() because the size is 8 bits, VarPackage() is unlimited
 
 #define ACPI_NAMESPACE_NAME        1

--- a/kernel/src/acpi/lai/src/ns_impl.h
+++ b/kernel/src/acpi/lai/src/ns_impl.h
@@ -1,0 +1,16 @@
+/*
+ * Lux ACPI Implementation
+ * Copyright (C) 2019 by LAI contributors
+ */
+
+// Internal header file. Do not use outside of LAI.
+
+#pragma once
+
+#include <lai.h>
+
+// Namespace management.
+acpi_nsnode_t *acpins_create_nsnode();
+acpi_nsnode_t *acpins_create_nsnode_or_die();
+void acpins_install_nsnode(acpi_nsnode_t *node);
+

--- a/kernel/src/acpi/lai/src/windozz/lai_system.h
+++ b/kernel/src/acpi/lai/src/windozz/lai_system.h
@@ -16,7 +16,11 @@
 #define acpi_debug(...)            debug_printf(LEVEL_DEBUG, "acpi", __VA_ARGS__)
 #define acpi_warn(...)            debug_printf(LEVEL_WARN, "acpi", __VA_ARGS__)
 
-#define acpi_panic(...)            debug_printf(LEVEL_ERROR, "acpi", __VA_ARGS__); \
-                            while(1);
+#define acpi_panic(...) \
+    do { \
+        debug_printf(LEVEL_ERROR, "acpi", __VA_ARGS__); \
+        while(1) \
+            ; \
+    } while(0)
 
 typedef mutex_t acpi_lock_t;

--- a/kernel/src/mm/mm.c
+++ b/kernel/src/mm/mm.c
@@ -58,12 +58,15 @@ void *krealloc(void *old, size_t new_size)
     if(!new)
         return NULL;
 
-    size_t *s_old;
-    s_old = (size_t *)((uintptr_t)old - 16);
+    if(old)
+    {
+        size_t *s_old;
+        s_old = (size_t *)((uintptr_t)old - 16);
 
-    memcpy(new, old, s_old[1]);
+        memcpy(new, old, s_old[1]);
 
-    kfree(old);
+        kfree(old);
+    }
     return new;
 }
 


### PR DESCRIPTION
Allocates the NS nodes individually. Rationale is in the commit messages. Also contains a bit of cleanup in the first and third patch.